### PR TITLE
Introduce a separate Account class

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ All devs in Radix, whether frontend or backend, surely have written helpers that
 I have already implemented one helper here, which makes it easier to fetch an account's balances.
 
 ```ts
-const account = "account_rdx1cx26ckdep9t0lut3qaz3q8cj9wey3tdee0rdxhc5f0nce64lw5gt70"
 const gateway = new GatewayEzMode()
-const balances = await gateway.getAllFungibleAccountBalances(account)
-console.log(balance)
+const account = gateway.getAccount(SOME_RANDOM_ACCOUNT)
+const balances = await account.getFungibleBalances()
+console.log(balances)
 
 /*
 output:

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,17 @@
+import { GatewayApiClient } from "@radixdlt/babylon-gateway-api-sdk";
+import { FungibleResourceBalance } from "./types";
+import { getFungibleBalancesForAccount } from "./accountBalances";
+
+export class Account {
+    private gateway: GatewayApiClient;
+    address: string;
+
+    constructor(address: string, gateway: GatewayApiClient = GatewayApiClient.initialize({ applicationName: '', networkId: 1 })) {
+        this.gateway = gateway;
+        this.address = address;
+    }
+
+    getFungibleBalances(): Promise<FungibleResourceBalance[]> {
+        return getFungibleBalancesForAccount(this.gateway, this.address)
+    }
+}

--- a/src/accountBalances.ts
+++ b/src/accountBalances.ts
@@ -16,7 +16,7 @@ function extractUrlMetadata(metadataItems: EntityMetadataCollection, key: string
     return item.value.typed.value;
 }
 
-export async function getBalancesForAccount(gatewayApi: GatewayApiClient, address: string): Promise<FungibleResourceBalance[]> {
+export async function getFungibleBalancesForAccount(gatewayApi: GatewayApiClient, address: string): Promise<FungibleResourceBalance[]> {
     const balances = await gatewayApi.state.innerClient.entityFungiblesPage({
         stateEntityFungiblesPageRequest: {
             address: address,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,10 @@
 import { GatewayEzMode } from ".";
+import { Account } from "./account";
+
+
+const RATTA_RESOURCE = "resource_rdx1t5wuuwfg3uk2y5l88rya553t3v4zyepf7wjekphryw6yepedyf7pug"
+const SOME_RANDOM_ACCOUNT = "account_rdx1cx26ckdep9t0lut3qaz3q8cj9wey3tdee0rdxhc5f0nce64lw5gt70"
+const DELETED_RATTA_ACCOUNT = "account_rdx12xru8aww4w73rr7r3wrc9nk428jr93efxvwtazen7hs3u43cyl5ssv"
 
 describe('gatewaySdk', () => {
     it('should initialize correctly', () => {
@@ -11,26 +17,30 @@ describe('gatewaySdk', () => {
     });
 
     it('should not error when I ask for an accounts balances', async () => {
-        const account = "account_rdx1cx26ckdep9t0lut3qaz3q8cj9wey3tdee0rdxhc5f0nce64lw5gt70"
         const gateway = new GatewayEzMode
-        const balances = await gateway.getAllFungibleAccountBalances(account)
+        const account = gateway.getAccount(SOME_RANDOM_ACCOUNT)
+        const balances = await account.getFungibleBalances()
         console.log(balances)
         expect(balances).toBeDefined()
     });
 
     // I put 1 RÅTTA in this account and then deleted access to it on-ledger so this test should always pass
     it('should see 1 ratta in this account', async () => {
-        const account = "account_rdx12xru8aww4w73rr7r3wrc9nk428jr93efxvwtazen7hs3u43cyl5ssv"
-        const rattaResourceAddress = "resource_rdx1t5wuuwfg3uk2y5l88rya553t3v4zyepf7wjekphryw6yepedyf7pug"
         const gateway = new GatewayEzMode
-        const balances = await gateway.getAllFungibleAccountBalances(account)
+        const account = gateway.getAccount(DELETED_RATTA_ACCOUNT)
+        const balances = await account.getFungibleBalances()
         expect(balances).toBeDefined()
-        expect(balances.length).toBe(1)
-        const rattaBalance = balances.find((balance) => balance.token.resourceAddress === rattaResourceAddress)
+        const rattaBalance = balances.find((balance) => balance.token.resourceAddress === RATTA_RESOURCE)
         if (!rattaBalance) {
             throw new Error("No ratta balance found")
         }
         expect(rattaBalance.balance).toBe("1")
-        expect(rattaBalance.token.resourceAddress).toBe("resource_rdx1t5wuuwfg3uk2y5l88rya553t3v4zyepf7wjekphryw6yepedyf7pug")
+        expect(rattaBalance.token.resourceAddress).toBe(RATTA_RESOURCE)
+    });
+
+    // use the account class on its own with a regular gateway instance
+    it('should be able to get the gateways status', async () => {
+        const account = new Account(SOME_RANDOM_ACCOUNT)
+        await account.getFungibleBalances()
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { GatewayApiClient } from "@radixdlt/babylon-gateway-api-sdk"
-import { getBalancesForAccount as getFungibleBalancesForAccount } from "./accountBalances"
-import { FungibleResourceBalance } from "./types"
+import { Account } from "./account"
 
 
 // Please add methods to this class to extend the functionality
@@ -17,7 +16,7 @@ export class GatewayEzMode {
         }
     }
 
-    async getAllFungibleAccountBalances(accountAddress: string): Promise<FungibleResourceBalance[]> {
-        return getFungibleBalancesForAccount(this.gateway, accountAddress)
+    getAccount(address: string): Account {
+        return new Account(address, this.gateway)
     }
 }


### PR DESCRIPTION
Stelea (RDX) suggested splitting helpers into logical units related to their functionality on ledger, and I liked this idea, so I did the first example of this here for the account.