### PR TITLE
Refactor metadata extraction

### DIFF
--- a/.changeset/great-phones-dress.md
+++ b/.changeset/great-phones-dress.md
@@ -2,4 +2,5 @@
 '@calamari-radix/gateway-ez-mode': minor
 ---
 
-Updated metadata extraction by introducing a more generic metadata extraction framework with nice type inference, and refactor some of the resource info fetching functions to use this new method
+Updated metadata extraction by introducing a more generic metadata extraction framework with nice type inference, and refactor some of the resource info fetching functions to use this new method.
+Updated ResourceInfo interface to include functions to fetch metadata, which enables users to fetch custom metadata other than the default ones provided in the metadata standard, which were already included in that object.

--- a/.changeset/great-phones-dress.md
+++ b/.changeset/great-phones-dress.md
@@ -1,0 +1,5 @@
+---
+'@calamari-radix/gateway-ez-mode': minor
+---
+
+Updated metadata extraction by introducing a more generic metadata extraction framework with nice type inference, and refactor some of the resource info fetching functions to use this new method

--- a/packages/gateway-ez-mode/src/balance/fungibleAccountBalances.ts
+++ b/packages/gateway-ez-mode/src/balance/fungibleAccountBalances.ts
@@ -3,11 +3,7 @@ import {
     ResourceAggregationLevel,
 } from '@radixdlt/babylon-gateway-api-sdk';
 import { FungibleResourceBalance } from '../types';
-import {
-    extractStringArrayMetadata,
-    extractStringMetadata,
-    extractUrlMetadata,
-} from '../data_extractors/metadata';
+import { extractAllMetadataValues } from '../data_extractors/metadata';
 
 export async function getFungibleBalancesForAccount(
     gatewayApi: GatewayApiClient,
@@ -57,40 +53,25 @@ export async function getFungibleBalancesForAccount(
                 return [];
             }
 
-            const tokenSymbol = extractStringMetadata(
-                tokenInfoItem.metadata,
-                'symbol'
-            );
-            const tokenName = extractStringMetadata(
-                tokenInfoItem.metadata,
-                'name'
-            );
-            const tokenDescription = extractStringMetadata(
-                tokenInfoItem.metadata,
-                'description'
-            );
-            const tokenIconUrl = extractUrlMetadata(
-                tokenInfoItem.metadata,
-                'icon_url'
-            );
-            const tokenInfoUrl = extractUrlMetadata(
-                tokenInfoItem.metadata,
-                'info_url'
-            );
-            const tokenTags = extractStringArrayMetadata(
-                tokenInfoItem.metadata,
-                'tags'
-            );
+            const { symbol, name, description, icon_url, info_url, tags } =
+                extractAllMetadataValues(tokenInfoItem.metadata, {
+                    symbol: 'String',
+                    name: 'String',
+                    description: 'String',
+                    icon_url: 'Url',
+                    info_url: 'Url',
+                    tags: 'StringArray',
+                });
 
             return {
                 resourceInfo: {
                     resourceAddress: item.resource_address,
-                    name: tokenName,
-                    iconUrl: tokenIconUrl,
-                    symbol: tokenSymbol,
-                    description: tokenDescription,
-                    tags: tokenTags,
-                    infoUrl: tokenInfoUrl,
+                    symbol,
+                    name,
+                    description,
+                    iconUrl: icon_url,
+                    infoUrl: info_url,
+                    tags,
                 },
                 balance: item.amount,
             };

--- a/packages/gateway-ez-mode/src/balance/nftBalances.ts
+++ b/packages/gateway-ez-mode/src/balance/nftBalances.ts
@@ -3,11 +3,7 @@ import {
     ResourceAggregationLevel,
 } from '@radixdlt/babylon-gateway-api-sdk';
 import { NftBalance, ResourceInfo } from '../types';
-import {
-    extractStringArrayMetadata,
-    extractStringMetadata,
-    extractUrlMetadata,
-} from '../data_extractors/metadata';
+import { extractAllMetadataValues } from '../data_extractors/metadata';
 import { extractStringNftData } from '../data_extractors/nftData';
 
 export async function getNonFungibleBalancesForAccount(
@@ -64,29 +60,26 @@ export async function getNonFungibleBalancesForAccount(
         if (!tokenInfoItem) return [];
         if (tokenInfoItem?.details?.type != 'NonFungibleResource') return [];
 
-        const tokenName = extractStringMetadata(tokenInfoItem.metadata, 'name');
-        const tokenDescription = extractStringMetadata(
-            tokenInfoItem.metadata,
-            'description'
-        );
-        const tokenSymbol = extractStringMetadata(
-            tokenInfoItem.metadata,
-            'symbol'
-        );
-        const iconUrl = extractUrlMetadata(tokenInfoItem.metadata, 'icon_url');
-        const infoUrl = extractUrlMetadata(tokenInfoItem.metadata, 'info_url');
-        const tags = extractStringArrayMetadata(tokenInfoItem.metadata, 'tags');
+        const { name, description, symbol, icon_url, info_url, tags } =
+            extractAllMetadataValues(tokenInfoItem.metadata, {
+                symbol: 'String',
+                name: 'String',
+                description: 'String',
+                icon_url: 'Url',
+                info_url: 'Url',
+                tags: 'StringArray',
+            });
 
         const nonFungibleIds = item.vaults.items.flatMap(
             (item) => item.items || []
         );
         const resourceInfo: ResourceInfo = {
             resourceAddress: item.resource_address,
-            name: tokenName,
-            description: tokenDescription,
-            symbol: tokenSymbol,
-            iconUrl: iconUrl,
-            infoUrl: infoUrl,
+            symbol,
+            name,
+            description,
+            iconUrl: icon_url,
+            infoUrl: info_url,
             tags,
         };
         return (async (): Promise<NftBalance> => {

--- a/packages/gateway-ez-mode/src/data_extractors/metadata.ts
+++ b/packages/gateway-ez-mode/src/data_extractors/metadata.ts
@@ -8,7 +8,7 @@ type GetMetadataValueWithType<T extends MetadataTypedValue['type']> = Extract<
     { type: T }
 >;
 
-type OutputTypeForType<T extends MetadataTypedValue['type']> =
+export type OutputTypeForType<T extends MetadataTypedValue['type']> =
     GetMetadataValueWithType<T> extends {
         values: infer U;
     }
@@ -19,39 +19,45 @@ type OutputTypeForType<T extends MetadataTypedValue['type']> =
           ? U
           : never;
 
-export function extractMetadataValue<T extends MetadataTypedValue['type']>(
-    metadataItems: EntityMetadataCollection,
-    key: string,
-    type: T
-): OutputTypeForType<T> | null {
-    const item = metadataItems.items.find((item) => item.key === key);
-    if (!item) return null;
-    if (item.value.typed.type !== type) return null;
-
-    // If it's one of the array kinds, return `values`, else return `value`
-    if ('values' in item.value.typed) {
-        return item.value.typed.values as OutputTypeForType<T>;
-    } else if ('value' in item.value.typed) {
-        return item.value.typed.value as OutputTypeForType<T>;
-    } else {
-        throw new Error(
-            'metadata value should either have `value` or `values`'
-        );
-    }
-}
-
 export type MetadataValueDescription = {
     [key: string]: MetadataTypedValue['type'];
 };
 
-export function extractAllMetadataValues<T extends MetadataValueDescription>(
-    metadataItems: EntityMetadataCollection,
-    descriptions: T
-): { [K in keyof T]: OutputTypeForType<T[K]> | null } {
-    return Object.fromEntries(
-        Object.entries(descriptions).map(([key, type]) => [
-            key,
-            extractMetadataValue(metadataItems, key, type),
-        ])
-    ) as { [K in keyof T]: OutputTypeForType<T[K]> | null };
+export class MetadataExtractor {
+    private metadataItems: EntityMetadataCollection;
+
+    constructor(metadataItems: EntityMetadataCollection) {
+        this.metadataItems = metadataItems;
+    }
+
+    public extractMetadataValue<T extends MetadataTypedValue['type']>(
+        key: string,
+        type: T
+    ): OutputTypeForType<T> | null {
+        const item = this.metadataItems.items.find((item) => item.key === key);
+        if (!item) return null;
+        if (item.value.typed.type !== type) return null;
+
+        // If it's one of the array kinds, return `values`, else `value`
+        if ('values' in item.value.typed) {
+            return item.value.typed.values as OutputTypeForType<T>;
+        } else if ('value' in item.value.typed) {
+            return item.value.typed.value as OutputTypeForType<T>;
+        } else {
+            throw new Error(
+                'metadata value should either have `value` or `values`'
+            );
+        }
+    }
+
+    public extractAllMetadataValues<T extends MetadataValueDescription>(
+        descriptions: T
+    ): { [K in keyof T]: OutputTypeForType<T[K]> | null } {
+        return Object.fromEntries(
+            Object.entries(descriptions).map(([key, type]) => [
+                key,
+                this.extractMetadataValue(key, type),
+            ])
+        ) as { [K in keyof T]: OutputTypeForType<T[K]> | null };
+    }
 }

--- a/packages/gateway-ez-mode/src/data_extractors/metadata.ts
+++ b/packages/gateway-ez-mode/src/data_extractors/metadata.ts
@@ -1,31 +1,57 @@
-import { EntityMetadataCollection } from '@radixdlt/babylon-gateway-api-sdk';
+import {
+    EntityMetadataCollection,
+    MetadataTypedValue,
+} from '@radixdlt/babylon-gateway-api-sdk';
 
-export function extractStringMetadata(
+type GetMetadataValueWithType<T extends MetadataTypedValue['type']> = Extract<
+    MetadataTypedValue,
+    { type: T }
+>;
+
+type OutputTypeForType<T extends MetadataTypedValue['type']> =
+    GetMetadataValueWithType<T> extends {
+        values: infer U;
+    }
+        ? U
+        : GetMetadataValueWithType<T> extends {
+                value: infer U;
+            }
+          ? U
+          : never;
+
+export function extractMetadataValue<T extends MetadataTypedValue['type']>(
     metadataItems: EntityMetadataCollection,
-    key: string
-): string | null {
-    const item = metadataItems.items.find((item) => item.key == key);
+    key: string,
+    type: T
+): OutputTypeForType<T> | null {
+    const item = metadataItems.items.find((item) => item.key === key);
     if (!item) return null;
-    if (item.value.typed.type !== 'String') return null;
-    return item.value.typed.value;
+    if (item.value.typed.type !== type) return null;
+
+    // If it's one of the array kinds, return `values`, else return `value`
+    if ('values' in item.value.typed) {
+        return item.value.typed.values as OutputTypeForType<T>;
+    } else if ('value' in item.value.typed) {
+        return item.value.typed.value as OutputTypeForType<T>;
+    } else {
+        throw new Error(
+            'metadata value should either have `value` or `values`'
+        );
+    }
 }
 
-export function extractUrlMetadata(
-    metadataItems: EntityMetadataCollection,
-    key: string
-): string | null {
-    const item = metadataItems.items.find((item) => item.key == key);
-    if (!item) return null;
-    if (item.value.typed.type !== 'Url') return null;
-    return item.value.typed.value;
-}
+export type MetadataValueDescription = {
+    [key: string]: MetadataTypedValue['type'];
+};
 
-export function extractStringArrayMetadata(
+export function extractAllMetadataValues<T extends MetadataValueDescription>(
     metadataItems: EntityMetadataCollection,
-    key: string
-): string[] | null {
-    const item = metadataItems.items.find((item) => item.key == key);
-    if (!item) return null;
-    if (item.value.typed.type !== 'StringArray') return null;
-    return item.value.typed.values;
+    descriptions: T
+): { [K in keyof T]: OutputTypeForType<T[K]> | null } {
+    return Object.fromEntries(
+        Object.entries(descriptions).map(([key, type]) => [
+            key,
+            extractMetadataValue(metadataItems, key, type),
+        ])
+    ) as { [K in keyof T]: OutputTypeForType<T[K]> | null };
 }

--- a/packages/gateway-ez-mode/src/index.test.ts
+++ b/packages/gateway-ez-mode/src/index.test.ts
@@ -23,7 +23,7 @@ describe('gatewaySdk', () => {
         const gateway = new GatewayEzMode();
         const account = gateway.getAccount(SOME_RANDOM_ACCOUNT);
         const balances = await account.getFungibleBalances();
-        console.log(balances);
+        console.log(balances[0]);
         expect(balances).toBeDefined();
     });
 
@@ -53,8 +53,6 @@ describe('gatewaySdk', () => {
     it('should be able to get nft balances', async () => {
         const account = new Account(SOME_RANDOM_ACCOUNT);
         const balances = await account.getNftBalances();
-        balances.forEach((balance) => {
-            console.log(balance);
-        });
+        console.log(balances[0]);
     });
 });

--- a/packages/gateway-ez-mode/src/index.ts
+++ b/packages/gateway-ez-mode/src/index.ts
@@ -12,6 +12,7 @@ import {
     TransactionStream,
     TransactionStreamInput,
 } from './stream/transactionStream';
+
 import s from '@calamari-radix/sbor-ez-mode';
 export { s };
 

--- a/packages/gateway-ez-mode/src/resource/information.ts
+++ b/packages/gateway-ez-mode/src/resource/information.ts
@@ -1,0 +1,40 @@
+import { GatewayApiClient } from '@radixdlt/babylon-gateway-api-sdk';
+import { ResourceInfo } from '../types';
+import { MetadataExtractor } from '../data_extractors/metadata';
+
+export async function fetchResourceInformation(
+    gateway: GatewayApiClient,
+    resourceAddresses: string[]
+): Promise<ResourceInfo[]> {
+    const tokenInfoItems =
+        await gateway.state.getEntityDetailsVaultAggregated(resourceAddresses);
+
+    return tokenInfoItems.flatMap((item) => {
+        const metadataExtractor = new MetadataExtractor(item.metadata);
+        const { symbol, name, description, icon_url, info_url, tags } =
+            metadataExtractor.extractAllMetadataValues({
+                symbol: 'String',
+                name: 'String',
+                description: 'String',
+                icon_url: 'Url',
+                info_url: 'Url',
+                tags: 'StringArray',
+            });
+
+        return {
+            resourceAddress: item.address,
+            symbol,
+            name,
+            description,
+            iconUrl: icon_url,
+            infoUrl: info_url,
+            tags,
+            getMetadataValue:
+                metadataExtractor.extractMetadataValue.bind(metadataExtractor),
+            getMetadataValues:
+                metadataExtractor.extractAllMetadataValues.bind(
+                    metadataExtractor
+                ),
+        };
+    });
+}

--- a/packages/gateway-ez-mode/src/stream/stream.test.ts
+++ b/packages/gateway-ez-mode/src/stream/stream.test.ts
@@ -16,18 +16,8 @@ describe(
             });
             let transactions = await stream.next();
             while (transactions.lastSeenStateVersion < TO_STATE_VERSION) {
-                console.log(
-                    transactions.transactions.map((tx) => tx.state_version)
-                );
                 transactions = await stream.next();
                 await new Promise((resolve) => setTimeout(resolve, 1000));
-                transactions.transactions.forEach((tx) => {
-                    tx.receipt?.detailed_events?.forEach((event) => {
-                        if (event.identifier.event == 'SwapEvent') {
-                            console.log(event);
-                        }
-                    });
-                });
             }
         });
     },

--- a/packages/gateway-ez-mode/src/types.ts
+++ b/packages/gateway-ez-mode/src/types.ts
@@ -1,3 +1,5 @@
+import { MetadataExtractor } from './data_extractors/metadata';
+
 export interface ResourceInfo {
     resourceAddress: string;
     name: string | null;
@@ -6,6 +8,8 @@ export interface ResourceInfo {
     iconUrl: string | null;
     infoUrl: string | null;
     tags: string[] | null;
+    getMetadataValue: typeof MetadataExtractor.prototype.extractMetadataValue;
+    getMetadataValues: typeof MetadataExtractor.prototype.extractAllMetadataValues;
 }
 
 export interface FungibleResourceBalance {

--- a/packages/sbor-ez-mode/src/index.test.ts
+++ b/packages/sbor-ez-mode/src/index.test.ts
@@ -20,8 +20,7 @@ function evaluateResultHelper<S extends SborSchema<any>, E>(
     }
 }
 
-// Example usage:
-describe('boing', () => {
+describe('sbor', () => {
     it('parse a complex example', () => {
         const schema = s.struct({
             updates: s.array(
@@ -50,8 +49,6 @@ describe('boing', () => {
         } else {
             throw new Error('Failed to parse');
         }
-
-        // console.log(JSON.stringify(result, null, 2));
     });
 
     it('parse a struct', () => {
@@ -149,22 +146,10 @@ describe('boing', () => {
         boingEvents.forEach((event) => {
             const result = schema.safeParse(event);
             if (result.success) {
-                switch (result.data.variant) {
-                    case 'StructBased':
-                        console.log(result.data.value.name);
-                        break;
-                    case 'TupleBasedTwoVals':
-                        console.log(result.data);
-                        break;
-                    case 'ContainsOption':
-                        console.log(result.data.value.option.variant);
-                        break;
-                }
+                // console.log(result.data);
             } else {
-                console.error(result.error);
                 throw new Error('Failed to parse');
             }
-            console.log(JSON.stringify(result, null, 2));
         });
     });
 
@@ -206,14 +191,6 @@ describe('boing', () => {
             key: s.string(),
             value: s.string(),
         });
-        const result = schema.safeParse(example);
-        if (result.success) {
-            console.log(result.data);
-            expect(result.data).toEqual(parsed);
-        } else {
-            console.error(result.error);
-            throw new Error('Failed to parse');
-        }
         evaluateResultHelper(schema, example, parsed);
     });
 


### PR DESCRIPTION
Create a more generic metadata extractor to extract metadata from the "typed" metadata field. 

It allows you to give a key, and one of the available types and typescript will be able to infer the return type of the metadata. 